### PR TITLE
github: allow Embedded Meetup Toulouse to create events

### DIFF
--- a/.github/COPILOT_EVENT_WORKFLOW.md
+++ b/.github/COPILOT_EVENT_WORKFLOW.md
@@ -29,6 +29,7 @@ Mapper le nom de communauté vers son slug en consultant `_groups/` :
 | AWS User Group Toulouse | aws |
 | C++ Toulouse | cpp |
 | Devops & Cloud Toulouse | devops-cloud |
+| Embedded Meetup Toulouse | embedded |
 | GDG Toulouse | gdg |
 | JS & Co Toulouse | js-and-co |
 | JUG Toulouse | jug |

--- a/.github/ISSUE_TEMPLATE/add-event.yml
+++ b/.github/ISSUE_TEMPLATE/add-event.yml
@@ -29,6 +29,7 @@ body:
         - AWS User Group Toulouse
         - C++ Toulouse
         - Devops & Cloud Toulouse
+        - Embedded Meetup Toulouse
         - GDG Toulouse
         - JS & Co Toulouse
         - JUG Toulouse


### PR DESCRIPTION
## Description

L'Embedded Meetup Toulouse étant présent sur Linkedin et non sur le site Meetup, les évènements doivent être créés manuellement via la section Issue du github Toulouse Tech Hub. Cette PR ajoute Embedded Meetup Toulouse comme organisateur d'évènements pour pouvoir créer les évènements correspondants.

## Type de changement

- [x] 🐛 Correction de bug (change non-cassante qui résout un problème)
- [ ] ✨ Nouvelle fonctionnalité (change non-cassante qui ajoute une fonctionnalité)
- [ ] 📝 Documentation (modification de README, CONTRIBUTING, etc.)
- [ ] 🎨 Refactorisation (amélioration du code sans changer la fonctionnalité)
- [ ] ⚙️ Dépendances (mise à jour de jekyll, gems, actions, etc.)

## Changements

- Ajoute Embedded Meetup Toulouse dans la liste des organisateurs, dans le template des issues "events'
- Ajoute le slug embedded pour l'automatisation via Copilot des évènements

## Testing

Comment as-tu testé ces changements ?

- [ ] `jekyll build` exécuté localement sans erreurs
- [ ] Site visité localement sur http://localhost:4000
- [ ] Changements fonctionnels vérifiés
- [ ] Aucun changement non intentionnel introduit

N/A, pas de changement sur le site

### Étapes de test

N/A

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Aucun fichier `_site/` commité
- [x] Pas de secrets ou credentials commitées
- [x] Les changements résolvent le problème décrit
- [x] J'ai testé localement

## Captures d'écran (si applicable)

N/A

## Notes supplémentaires