### PR TITLE
feat(groups): add dedicated community pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,8 +9,16 @@ archive_days: 365
 
 collections:
   groups:
-    output: false
+    output: true
+    permalink: /groups/:slug/
   confs:
     output: false
   events:
     output: false
+
+defaults:
+  - scope:
+      path: ""
+      type: groups
+    values:
+      layout: group

--- a/_includes/group-calendar.ics
+++ b/_includes/group-calendar.ics
@@ -23,7 +23,7 @@ X-WR-TIMEZONE:Europe/Paris
 BEGIN:VEVENT
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 DTSTART;TZID=Europe/Paris:{{ event.dateIso | date: "%Y%m%d" }}T{{ event.dateIso | date: "%H%M" }}00
-DTEND;TZID=Europe/Paris:{% if event.dateIsoEnd %}{{ event.dateIsoEnd | date: "%Y%m%d" }}T{{ event.dateIsoEnd | date: "%H%M" }}00{% else %}{{ event.dateIso | date: "%Y%m%d" }}T{{ event.dateIso | date: "%s" | plus: 7200 | date: "%H%M" }}00{% endif %}
+DTEND;TZID=Europe/Paris:{% if event.dateIsoEnd %}{{ event.dateIsoEnd | date: "%Y%m%dT%H%M%S" }}{% else %}{{ event.dateIso | date: "%s" | plus: 7200 | date: "%Y%m%dT%H%M%S" }}{% endif %}
 SEQUENCE:0
 SUMMARY:{{ event.title | strip | replace: "\n", " " | replace: ",", "\\," | replace: ";", "\\;" }}
 UID:{{ event.eventId }}@toulouse-tech-hub.fr

--- a/_includes/group-calendar.ics
+++ b/_includes/group-calendar.ics
@@ -1,0 +1,52 @@
+{% assign now_time = site.time | date: "%s" | plus: 0 -%}
+{% assign current_group = site.groups | where: "slug", include.group_slug | first -%}
+{% assign skipped_event_paths = site.events | where_exp: "e", "e.path contains '.skip'" | map: "path" -%}
+BEGIN:VCALENDAR
+PRODID:-//toulouse-tech-hub.fr//{{ include.group_slug }} calendar//FR
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:Toulouse Tech Hub - {{ current_group.name | default: include.group_slug }}
+X-WR-TIMEZONE:Europe/Paris
+{% for event in site.events reversed -%}
+{% if event.path contains ".skip" -%}
+{% continue -%}
+{% endif -%}
+{% assign event_skip_path = event.path | append: ".skip" -%}
+{% if skipped_event_paths contains event_skip_path -%}
+{% continue -%}
+{% endif -%}
+{% assign event_time = event.dateIso | date: "%s" | plus: 0 -%}
+{% if event.groupId != include.group_slug or event_time < now_time -%}
+{% continue -%}
+{% endif -%}
+BEGIN:VEVENT
+DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
+DTSTART;TZID=Europe/Paris:{{ event.dateIso | date: "%Y%m%d" }}T{{ event.dateIso | date: "%H%M" }}00
+DTEND;TZID=Europe/Paris:{% if event.dateIsoEnd %}{{ event.dateIsoEnd | date: "%Y%m%d" }}T{{ event.dateIsoEnd | date: "%H%M" }}00{% else %}{{ event.dateIso | date: "%Y%m%d" }}T{{ event.dateIso | date: "%s" | plus: 7200 | date: "%H%M" }}00{% endif %}
+SEQUENCE:0
+SUMMARY:{{ event.title | strip | replace: "\n", " " | replace: ",", "\\," | replace: ";", "\\;" }}
+UID:{{ event.eventId }}@toulouse-tech-hub.fr
+URL:{{ event.link }}
+DESCRIPTION:{{ event.community | strip | replace: "\n", " " }} - {{ event.link }}
+END:VEVENT
+{% endfor -%}
+BEGIN:VTIMEZONE
+TZID:Europe/Paris
+X-LIC-LOCATION:Europe/Paris
+BEGIN:STANDARD
+DTSTART:20231029T030000
+RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
+TZNAME:CET
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:20240331T020000
+RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3
+TZNAME:CEST
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+END:DAYLIGHT
+END:VTIMEZONE
+END:VCALENDAR

--- a/_includes/group-events.html
+++ b/_includes/group-events.html
@@ -1,0 +1,50 @@
+{%- assign now_time = site.time | date: "%s" | plus: 0 -%}
+{%- assign group_events = site.events | where: "groupId", include.group_slug -%}
+{%- assign skipped_event_paths = site.events | where_exp: "e", "e.path contains '.skip'" | map: "path" -%}
+{%- assign future_events = "" | split: "" -%}
+{%- for event in group_events -%}
+  {%- if event.path contains ".skip" -%}
+    {%- continue -%}
+  {%- endif -%}
+  {%- assign event_skip_path = event.path | append: ".skip" -%}
+  {%- if skipped_event_paths contains event_skip_path -%}
+    {%- continue -%}
+  {%- endif -%}
+  {%- assign event_time = event.dateIso | date: "%s" | plus: 0 -%}
+  {%- if event_time >= now_time -%}
+    {%- assign future_events = future_events | push: event -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- if future_events.size > 0 -%}
+<section class="mt-5">
+  <h2 class="fw-light mb-3">Prochains évènements</h2>
+  <div class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 g-3">
+  {%- for event in future_events -%}
+    {%- assign date_part = event.dateIso | date: "%Y-%m-%d" -%}
+    {%- capture image_path %}event-imgs/{{ date_part }}-{{ event.groupId }}-{{ event.eventId }}.webp{% endcapture -%}
+    <div class="col">
+      <div class="card shadow h-100">
+        <a href="{{ event.link }}" target="_blank" rel="noopener noreferrer">
+          <img width="100%" style="aspect-ratio: 16/9; object-fit: cover;" src="{{ site.baseurl }}/{{ image_path }}"
+            {%- if event.img and event.img != "" %} onerror="this.onerror=null; this.src='{{ event.img }}';"{% endif -%} />
+          <div class="card-body">
+            <h5 class="card-title">{{ event.title }}</h5>
+            <div class="d-flex justify-content-between align-items-center">
+              <small class="text-muted place">
+                {%- if event.place != null and event.place != "" -%}
+                🏠 {{ event.place }}<br>📍 {{ event.placeAddr }}
+                {%- else -%}
+                🌍 en ligne
+                {%- endif -%}
+              </small>
+              <small class="text-muted text-end time">{{ event.dateFr }}📅<br>{{ event.timeFr }}⌚</small>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  {%- endfor -%}
+  </div>
+</section>
+{%- endif -%}

--- a/_includes/group-events.html
+++ b/_includes/group-events.html
@@ -26,7 +26,7 @@
     <div class="col">
       <div class="card shadow h-100">
         <a href="{{ event.link }}" target="_blank" rel="noopener noreferrer">
-          <img width="100%" style="aspect-ratio: 16/9; object-fit: cover;" src="{{ site.baseurl }}/{{ image_path }}"
+          <img width="100%" style="aspect-ratio: 16/9; object-fit: cover;" src="{{ site.baseurl }}/{{ image_path }}" alt="{{ event.title | escape }}"
             {%- if event.img and event.img != "" %} onerror="this.onerror=null; this.src='{{ event.img }}';"{% endif -%} />
           <div class="card-body">
             <h5 class="card-title">{{ event.title }}</h5>

--- a/_includes/group-feed.xml
+++ b/_includes/group-feed.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+{%- assign now_time = site.time | date: "%s" | plus: 0 -%}
+{%- assign current_group = site.groups | where: "slug", include.group_slug | first -%}
+{%- assign group_name = current_group.name | default: include.group_slug -%}
+{%- assign feed_url = site.site | append: site.baseurl | append: "/groups/" | append: include.group_slug | append: "/feed.xml" -%}
+{%- assign skipped_event_paths = site.events | where_exp: "e", "e.path contains '.skip'" | map: "path" -%}
+<feed xmlns:media="http://search.yahoo.com/mrss/" xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ group_name | replace: "&", "&amp;" }} - Toulouse Tech Hub</title>
+  <subtitle>Prochains évènements de {{ group_name | replace: "&", "&amp;" }} à Toulouse</subtitle>
+  <author><name>Toulouse Tech Hub</name></author>
+  <link rel="self" href="{{ feed_url }}" />
+  <link rel="alternate" href="{{ site.site }}{{ site.baseurl }}/groups/{{ include.group_slug }}/" />
+  <id>urn:toulouse-tech-hub:group:{{ include.group_slug }}</id>
+  <updated>{{ site.time | date: "%Y-%m-%dT%T" }}+01:00</updated>
+{%- for event in site.events reversed -%}
+{%- if event.groupId != include.group_slug -%}{%- continue -%}{%- endif -%}
+{%- if event.path contains ".skip" -%}{%- continue -%}{%- endif -%}
+{%- assign event_skip_path = event.path | append: ".skip" -%}
+{%- if skipped_event_paths contains event_skip_path -%}{%- continue -%}{%- endif -%}
+{%- assign event_date_time = event.dateIso | date: "%s" | plus: 0 -%}
+{%- if event_date_time < now_time -%}{%- continue -%}{%- endif -%}
+{%- assign published_time = event.datePublished | date: "%s" | plus: 0 -%}
+{%- if published_time > now_time -%}{%- continue -%}{%- endif -%}
+{%- assign tz = event.dateIso | date: "%z" -%}
+{%- assign date_part = event.dateIso | date: "%Y-%m-%d" -%}
+{%- capture image_path %}event-imgs/{{ date_part }}-{{ event.groupId }}-{{ event.eventId }}.webp{% endcapture -%}
+  <entry>
+    <id>urn:{{ event.eventId }}</id>
+    <published>{{ event.datePublished | date: "%Y-%m-%dT%T" }}{{ tz | slice: 0, 3 }}:00</published>
+    <updated>{{ event.datePublished | date: "%Y-%m-%dT%T" }}{{ tz | slice: 0, 3 }}:00</updated>
+    <title>{{ event.dateFr }} à {{ event.timeFr }} : {{ event.title | replace: "&", "&amp;" | replace: "<", "&lt;" }}</title>
+    <link rel="alternate" href="{{ event.link }}" />
+    <author><name>{{ event.community | replace: "&", "&amp;" | replace: "<", "&lt;" }}</name></author>
+    <media:thumbnail url="{{ site.site }}{{ site.baseurl }}/{{ image_path }}" />
+    <link rel="enclosure" type="image/webp" href="{{ site.site }}{{ site.baseurl }}/{{ image_path }}" />
+    <content type="html">{{ event.content | replace: "&", "&amp;" | replace: "<", "&lt;" | replace: ">", "&gt;" }}</content>
+  </entry>
+{%- endfor %}
+</feed>

--- a/_includes/group-feed.xml
+++ b/_includes/group-feed.xml
@@ -11,7 +11,7 @@
   <link rel="self" href="{{ feed_url }}" />
   <link rel="alternate" href="{{ site.site }}{{ site.baseurl }}/groups/{{ include.group_slug }}/" />
   <id>urn:toulouse-tech-hub:group:{{ include.group_slug }}</id>
-  <updated>{{ site.time | date: "%Y-%m-%dT%T" }}+01:00</updated>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
 {%- for event in site.events reversed -%}
 {%- if event.groupId != include.group_slug -%}{%- continue -%}{%- endif -%}
 {%- if event.path contains ".skip" -%}{%- continue -%}{%- endif -%}

--- a/_includes/groups.html
+++ b/_includes/groups.html
@@ -9,6 +9,7 @@
     {%- capture group_img_url -%}{{ site.baseurl }}/groups-imgs/{{ group.slug }}.jpg{%- endcapture -%}
   {%- endunless -%}
   <div class="card community-card {{ gradient_class | strip }}{% if group_img_url != "" %} community-card-with-img{% endif %}"{% if group_img_url != "" %} style="background-image: url('{{ group_img_url }}');"{% endif %}>
+    <a class="community-card-main-link" href="{{ group.url | relative_url }}" aria-label="Voir la communauté {{ group.name | escape }}"></a>
     <div class="community-card-body">
       <h5 class="community-card-title">{{ group.name }}</h5>
       {% if group.content %}
@@ -17,10 +18,10 @@
       <p class="community-card-desc">{{ group.description | strip_html | truncatewords: 15 }}</p>
       {% endif %}
       <div class="community-card-links">
-        <a href="{{ group.link }}" title="Site Web" target="_blank"><i class="bi bi-globe"></i></a>
+        <a href="{{ group.link }}" title="Site Web" target="_blank" rel="noopener noreferrer"><i class="bi bi-globe"></i></a>
         {%- if group.social -%}
           {%- for social in group.social -%}
-          <a href="{{ social.url }}" title="{{ social.title }}" target="_blank"><i class="bi {{ social.icon }}"></i></a>
+          <a href="{{ social.url }}" title="{{ social.title | escape }}" target="_blank" rel="noopener noreferrer"><i class="bi {{ social.icon }}"></i></a>
           {%- endfor -%}
         {%- endif -%}
       </div>

--- a/_layouts/group-calendar.ics
+++ b/_layouts/group-calendar.ics
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+{% include group-calendar.ics group_slug=page.group_slug %}

--- a/_layouts/group-feed.xml
+++ b/_layouts/group-feed.xml
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+{% include group-feed.xml group_slug=page.group_slug %}

--- a/_layouts/group.html
+++ b/_layouts/group.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/styles.css">
     <meta property="og:title" content="{{ page.name | escape }} - Toulouse Tech Hub" />
     <meta property="og:image" content="{{ site.site }}{{ site.baseurl }}/groups-imgs/{{ page.slug }}.jpg" />
-    <meta property="og:link" content="{{ site.site }}{{ site.baseurl }}{{ page.url }}" />
+    <meta property="og:url" content="{{ site.site }}{{ site.baseurl }}{{ page.url }}" />
     <link rel="alternate" type="application/atom+xml" href="{{ site.site }}{{ site.baseurl }}/groups/{{ page.slug }}/feed.xml" />
 </head>
 

--- a/_layouts/group.html
+++ b/_layouts/group.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html prefix="og: https://ogp.me/ns#">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.name | escape }} - Toulouse Tech Hub</title>
+    <script type="text/javascript">
+      function copyToClipboard(name, btn) {
+        var elt = document.getElementById(name);
+        if(!elt) return;
+        var url = elt.getAttribute('data-url');
+        navigator.clipboard.writeText(url);
+        var anchor = btn || elt;
+        var tooltip = bootstrap.Tooltip.getOrCreateInstance(anchor, { title: 'URL copiée !', trigger: 'manual'});
+        tooltip.show();
+        setTimeout(function() { tooltip.hide()}, 3000);
+      }
+    </script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/styles.css">
+    <meta property="og:title" content="{{ page.name | escape }} - Toulouse Tech Hub" />
+    <meta property="og:image" content="{{ site.site }}{{ site.baseurl }}/groups-imgs/{{ page.slug }}.jpg" />
+    <meta property="og:link" content="{{ site.site }}{{ site.baseurl }}{{ page.url }}" />
+    <link rel="alternate" type="application/atom+xml" href="{{ site.site }}{{ site.baseurl }}/groups/{{ page.slug }}/feed.xml" />
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-lg navbar-sticky fixed-top">
+        <div class="container">
+            <a class="navbar-brand fw-bold text-white" href="{{ site.baseurl }}/" style="font-size: 1.3rem;">TOULOUSE TECH HUB</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ site.baseurl }}/#agenda">📅 Agenda</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ site.baseurl }}/#conferences">📢 Conférences</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ site.baseurl }}/#communautes">🧑‍💻 Communautés</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container py-4">
+        <div class="row g-4 align-items-start mt-2">
+            <div class="col-lg-6">
+                {% if page.img == "none" %}
+                <div class="group-hero community-default community-{{ page.slug }}" style="aspect-ratio: 16/9; width: 100%;"></div>
+                {% else %}
+                <img src="{{ site.baseurl }}/groups-imgs/{{ page.slug }}.jpg" class="img-fluid group-hero" alt="Logo {{ page.name | escape }}" style="aspect-ratio: 16/9; object-fit: cover; width: 100%;" onerror="this.onerror=null; this.outerHTML='<div class=\'group-hero community-default community-{{ page.slug }}\' style=\'aspect-ratio:16/9;width:100%\'></div>';">
+                {% endif %}
+            </div>
+            <div class="col-lg-6">
+                {% assign group_ics_url = site.site | append: site.baseurl | append: page.url | append: "calendar.ics" %}
+                {% assign group_rss_url = site.site | append: site.baseurl | append: "/groups/" | append: page.slug | append: "/feed.xml" %}
+                {% assign group_ics_input_id = "icsInput-" | append: page.slug %}
+                {% assign group_rss_input_id = "rssInput-" | append: page.slug %}
+                <span hidden id="{{ group_ics_input_id }}" data-url="{{ group_ics_url }}"></span>
+                <span hidden id="{{ group_rss_input_id }}" data-url="{{ group_rss_url }}"></span>
+                <h1 class="group-title mb-3">{{ page.name }}</h1>
+                <div class="d-flex flex-wrap gap-2 align-items-center mb-3">
+                    {% if page.link %}
+                    <a class="btn btn-primary" href="{{ page.link }}" target="_blank" rel="noopener noreferrer">
+                        <i class="bi bi-box-arrow-up-right me-2"></i>Site officiel
+                    </a>
+                    {% endif %}
+                    <button class="btn btn-outline-secondary" type="button" title="Copier l'URL du calendrier iCal" onclick="copyToClipboard('{{ group_ics_input_id }}', this)">
+                        <i class="bi bi-calendar2-week me-1"></i>iCal
+                    </button>
+                    <button class="btn btn-outline-secondary" type="button" title="Copier l'URL du flux RSS/Atom" onclick="copyToClipboard('{{ group_rss_input_id }}', this)">
+                        <i class="bi bi-rss me-1"></i>RSS
+                    </button>
+                </div>
+                {% if page.social %}
+                <div class="group-social-links mb-3">
+                    {% for social in page.social %}
+                    <a href="{{ social.url }}" title="{{ social.title | escape }}" target="_blank" rel="noopener noreferrer">
+                        <i class="bi {{ social.icon }}"></i>
+                    </a>
+                    {% endfor %}
+                </div>
+                {% endif %}
+                <div class="group-description">
+                    {% assign stripped_content = content | strip %}
+                    {% if stripped_content != "" %}
+                    {{ content }}
+                    {% elsif page.description %}
+                    {{ page.description }}
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        {% include group-events.html group_slug=page.slug %}
+
+        <p class="mt-4 mb-4">
+            <a href="{{ site.baseurl }}/#communautes" class="muted">⬅️ Retour aux communautés</a>
+        </p>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/_plugins/group_feeds_generator.rb
+++ b/_plugins/group_feeds_generator.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module GroupCalendars
+  class GroupCalendarPage < Jekyll::PageWithoutAFile
+    def initialize(site, group)
+      slug = group.data["slug"] || group.basename_without_ext
+
+      @site = site
+      @base = site.source
+      @dir = "groups/#{slug}"
+      @name = "calendar.ics"
+
+      process(@name)
+
+      @data = {
+        "layout" => "group-calendar",
+        "group_slug" => slug,
+        "title" => "#{group.data['name'] || slug} calendar",
+        "sitemap" => false
+      }
+    end
+  end
+
+  class GroupFeedPage < Jekyll::PageWithoutAFile
+    def initialize(site, group)
+      slug = group.data["slug"] || group.basename_without_ext
+
+      @site = site
+      @base = site.source
+      @dir = "groups/#{slug}"
+      @name = "feed.xml"
+
+      process(@name)
+
+      @data = {
+        "layout" => "group-feed",
+        "group_slug" => slug,
+        "title" => "#{group.data['name'] || slug} feed",
+        "sitemap" => false
+      }
+    end
+  end
+
+  class GroupCalendarsGenerator < Jekyll::Generator
+    safe true
+    priority :low
+
+    def generate(site)
+      groups = site.collections.fetch("groups", nil)
+      return unless groups
+
+      groups.docs.each do |group|
+        site.pages << GroupCalendarPage.new(site, group)
+        site.pages << GroupFeedPage.new(site, group)
+      end
+    end
+  end
+end

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -84,6 +84,18 @@ a.muted {
     position: relative;
 }
 
+.community-card-main-link {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    border-radius: 12px;
+}
+
+.community-card-main-link:focus-visible {
+    outline: 3px solid rgba(255,255,255,0.9);
+    outline-offset: -4px;
+}
+
 .community-card-with-img {
     background-size: cover !important;
     background-repeat: no-repeat !important;
@@ -123,7 +135,8 @@ a.muted {
 
 .community-card-body {
     position: relative;
-    z-index: 2;
+    z-index: 4;
+    pointer-events: none;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
@@ -152,9 +165,12 @@ a.muted {
 .community-card-links {
     display: flex;
     gap: 12px;
+    position: relative;
+    z-index: 4;
 }
 
 .community-card-links a {
+    pointer-events: auto;
     color: white;
     text-decoration: none;
     font-size: 1.1rem;
@@ -176,6 +192,10 @@ a.muted {
 }
 
 /* Gradient backgrounds for specific communities */
+.community-default {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
 .community-gdg {
     background: linear-gradient(135deg, #EA4435 0%, #FBBC04 100%);
 }
@@ -219,6 +239,50 @@ a.muted {
 
 .community-default {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+/* Group detail page */
+.group-hero {
+    border-radius: 16px;
+    overflow: hidden;
+    border: 6px solid #ffffff;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,0.68), 0 8px 16px rgba(0,0,0,0.22);
+    display: block;
+}
+
+.group-title {
+    font-size: 2.8rem;
+    font-weight: 700;
+    line-height: 1.15;
+}
+
+.group-description {
+    font-size: 1rem;
+    line-height: 1.65;
+}
+
+.group-social-links {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.group-social-links a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    color: white;
+    text-decoration: none;
+    background: linear-gradient(135deg, rgba(255,137,74,1) 0%, rgba(38,166,154,1) 100%);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+
+.group-social-links a:hover {
+    color: white;
+    transform: translateY(-2px);
 }
 
 /* Calendar Styles */


### PR DESCRIPTION
## Description

Ajoute une page dédiée à chaque communauté afin d'améliorer la navigation et le référencement.

- rend la collection `groups` accessible sous `/groups/:slug/`
- relie chaque carte de communauté à sa page dédiée
- affiche les informations, liens sociaux et prochains événements de la communauté
- génère un calendrier iCal et un flux Atom propres à chaque communauté
- exclut les événements marqués `.skip` des pages et flux dédiés
- ajoute les styles responsive et les actions de copie des URL iCal/Atom

## Validation

- build Jekyll réussi
- 28 pages communautés générées
- 28 calendriers ICS générés
- 28 flux Atom XML bien formés
- rendu vérifié manuellement