### PR TITLE
content(groups): enrich community profiles

### DIFF
--- a/_groups/afup-toulouse.md
+++ b/_groups/afup-toulouse.md
@@ -2,6 +2,9 @@
 name: AFUP Toulouse
 link: https://www.meetup.com/afup-toulouse
 social:
+  - icon: bi-link-45deg
+    url: https://linktr.ee/afup_toulouse
+    title: "Tous les liens"
   - icon: bi-linkedin
     url: https://www.linkedin.com/company/afup-toulouse/
     title: "Page LinkedIn"

--- a/_groups/agile.md
+++ b/_groups/agile.md
@@ -1,6 +1,22 @@
 ---
 name: Agile Toulouse
 link: https://www.agiletoulouse.fr/
+social:
+  - icon: bi-calendar-check
+    url: https://www.meetup.com/agile-toulouse/
+    title: "Meetup"
+  - icon: bi-twitter-x
+    url: https://twitter.com/agiletoulouse
+    title: "Page X / Twitter"
+  - icon: bi-linkedin
+    url: https://www.linkedin.com/company/agile-toulouse/
+    title: "Page LinkedIn"
+  - icon: bi-youtube
+    url: https://www.youtube.com/channel/UCVw87gMcZSQ_JePgth6TFsQ
+    title: "Chaîne YouTube"
+  - icon: bi-discord
+    url: https://discord.gg/43AnVBjpwG
+    title: "Discord"
 ---
 
 Agile Toulouse anime la communauté agile à Toulouse et dans le Sud-Ouest à travers des rencontres, des ateliers et des événements thématiques.

--- a/_groups/aificionados.md
+++ b/_groups/aificionados.md
@@ -3,4 +3,6 @@ name: AI-ficionados
 link: https://aificionados.com/
 ---
 
-Le rendez-vous toulousain des Aficionados de l'IA.
+AI-ficionados rassemble à Toulouse les personnes qui s'intéressent à l'intelligence artificielle, qu'elles la découvrent ou qu'elles l'utilisent déjà dans leurs projets.
+
+La communauté propose un espace pour rencontrer d'autres passionnés, partager des expériences et échanger autour des usages, des outils et des évolutions de l'IA.

--- a/_groups/artilect.md
+++ b/_groups/artilect.md
@@ -2,6 +2,12 @@
 name: Artilect FabLab
 link: https://www.meetup.com/artilect-fablab/
 social:
+  - icon: bi-globe
+    url: https://artilect.fr/
+    title: "Site Web"
+  - icon: bi-facebook
+    url: https://www.facebook.com/ArtilectFabLabToulouse/
+    title: "Page Facebook"
   - icon: bi-twitter-x
     url: https://twitter.com/fablab_toulouse
     title: "Page X / Twitter"
@@ -11,6 +17,9 @@ social:
   - icon: bi-linkedin
     url: https://www.linkedin.com/company/artilect-fablab-toulouse
     title: "Page LinkedIn"
+  - icon: bi-youtube
+    url: https://www.youtube.com/channel/UCgmxPb9W7oDjXu_IyZdAJuQ
+    title: "Chaîne YouTube"
 ---
 
 Artilect est un tiers-lieu collaboratif en centre-ville de Toulouse, avec Fab Lab, coworking, café et espaces événementiels.

--- a/_groups/cpp.md
+++ b/_groups/cpp.md
@@ -1,6 +1,15 @@
 ---
 name: C++ Toulouse
 link: https://www.meetup.com/ateliers-cpp-toulouse/
+social:
+  - icon: bi-globe
+    url: https://toulibre.org/
+    title: "Association Toulibre"
+  - icon: bi-chat-dots
+    url: https://framateam.org/ateliers-cpp-toulibre/
+    title: "Chat Framateam"
 ---
 
-Conférences et ateliers en région toulousaine autour du développement en langage C++ . Ces rencontres sont organisées par l'association Toulibre .
+C++ Toulouse réunit les développeurs et curieux qui souhaitent découvrir ou approfondir le langage C++ et ses pratiques modernes.
+
+La communauté propose en région toulousaine des conférences et des ateliers pour apprendre, expérimenter et partager des retours d'expérience. Ces rencontres sont organisées par l'association Toulibre.

--- a/_groups/dataviz.md
+++ b/_groups/dataviz.md
@@ -2,9 +2,20 @@
 name: Toulouse Data-Viz
 link: https://www.meetup.com/meetup-visualisation-des-donnees-toulouse/
 social:
+  - icon: bi-globe
+    url: https://toulouse-dataviz.fr/
+    title: "Site Web"
+  - icon: bi-discord
+    url: https://discord.gg/Ch23qScbpc
+    title: "Discord"
+  - icon: bi-envelope
+    url: https://toulouse-dataviz.us20.list-manage.com/subscribe?u=6d06abd4e903b49060d162a89&id=31bc433cb4
+    title: "Newsletter"
   - icon: bi-twitter-x
-    url: http://twitter.com/Tls_dataviz
+    url: https://twitter.com/Tls_dataviz
     title: "Page X / Twitter"
 ---
 
-Ce groupe rassemble les personnes intéressées par la data visualisation pour échanger, découvrir des réalisations concrètes et s'approprier les outils de dataviz.
+Toulouse Data-Viz rassemble les personnes qui conçoivent, utilisent ou souhaitent découvrir la visualisation de données.
+
+La communauté propose des rencontres pratiques pour analyser des réalisations, partager des méthodes et mieux s'approprier les outils de dataviz. Les sujets abordés vont des fondamentaux de la représentation visuelle à l'accessibilité, en passant par les retours d'expérience et les coulisses de projets concrets.

--- a/_groups/devops-cloud.md
+++ b/_groups/devops-cloud.md
@@ -3,4 +3,6 @@ name: Devops & Cloud Toulouse
 link: https://www.meetup.com/devops-cloud-toulouse/
 ---
 
-Discussions, échanges et rencontres sur les sujets DevOps et Cloud.
+DevOps & Cloud Toulouse réunit les personnes intéressées par les pratiques DevOps et les technologies cloud, quels que soient leur métier ou leur niveau d'expérience.
+
+Les rencontres permettent de partager des retours d'expérience, de découvrir des outils et d'échanger autour de l'automatisation, du déploiement, des infrastructures et des architectures cloud.

--- a/_groups/devops.md
+++ b/_groups/devops.md
@@ -12,8 +12,13 @@ social:
     url: https://bsky.app/profile/toulouse-devops.org
     title: "Bluesky"
   - icon: bi-twitter-x
-    url: http://twitter.com/toulousedevops
+    url: https://twitter.com/toulousedevops
     title: "Page X / Twitter"
+  - icon: bi-github
+    url: https://github.com/toulousedevops
+    title: "GitHub"
 ---
 
-Ce groupe s'adresse à toutes les personnes intéressées par le DevOps. Nous y parlons d'automatisation du déploiement, de livraison continue, de cloud et de sujets associés.
+Toulouse DevOps rassemble les passionnés d'infrastructure, d'automatisation et de culture DevOps, qu'ils soient développeurs, ops, SRE ou simplement curieux.
+
+La communauté organise des meetups gratuits autour de talks techniques et de retours d'expérience. Les échanges portent notamment sur l'automatisation des déploiements, la livraison continue, le cloud et les pratiques qui rapprochent développement et opérations.

--- a/_groups/flupa.md
+++ b/_groups/flupa.md
@@ -1,10 +1,25 @@
 ---
 name: FLUPA Toulouse
-link: http://flupa.eu/
+link: https://flupa.eu/
 social:
+  - icon: bi-youtube
+    url: https://www.youtube.com/c/Flupa
+    title: "Chaîne YouTube"
+  - icon: bi-twitter-x
+    url: https://twitter.com/flupa
+    title: "Page X / Twitter"
   - icon: bi-linkedin
     url: https://www.linkedin.com/company/assoflupa/
     title: "Page LinkedIn"
+  - icon: bi-facebook
+    url: https://www.facebook.com/flupaflupa/
+    title: "Page Facebook"
+  - icon: bi-instagram
+    url: https://www.instagram.com/flupa_asso/
+    title: "Instagram"
+  - icon: bi-slack
+    url: https://join.slack.com/t/ux-flupa/shared_invite/zt-1j348apea-p_9e0g6Bo_Nbz13YrL_PCA
+    title: "Slack"
 ---
 
 FLUPA est la communauté dédiée aux professionnels et passionnés de l'UX Design au sens large. Son objectif est simple : créer des espaces d'échange concrets pour celles et ceux qui conçoivent les produits et services numériques d'aujourd'hui et de demain.

--- a/_groups/gdg.md
+++ b/_groups/gdg.md
@@ -11,6 +11,17 @@ social:
   - icon: bi-linkedin
     url: https://www.linkedin.com/company/gdg-toulouse
     title: "Page LinkedIn"
+  - icon: bi-facebook
+    url: https://www.facebook.com/GDGToulouse/
+    title: "Page Facebook"
+  - icon: bi-youtube
+    url: https://www.youtube.com/c/gdgtoulouse
+    title: "Chaîne YouTube"
+  - icon: bi-github
+    url: https://github.com/GDGToulouse/meetup/issues/new
+    title: "Proposer un sujet"
 ---
 
 Les Google Developers Groups (GDGs) sont des regroupements de personnes intéressées par les technologies et plateformes de Google: Android, Angular, Chrome, Google Apps, GWT, Cloud Platform… mais pas que !
+
+Le GDG Toulouse organise des rencontres techniques ouvertes à toutes et à tous. La communauté permet également de proposer de nouveaux sujets et de retrouver les présentations passées sur YouTube.

--- a/_groups/ia-innovateurs.md
+++ b/_groups/ia-innovateurs.md
@@ -5,6 +5,9 @@ social:
   - icon: bi-linkedin
     url: https://www.linkedin.com/groups/15076013/
     title: "Page LinkedIn"
+  - icon: bi-whatsapp
+    url: https://chat.whatsapp.com/BfWXEUob0402c1XAZVEzfg
+    title: "Groupe WhatsApp"
 ---
 
 Rejoignez IA Innovateurs Toulouse, la communauté incontournable pour découvrir, apprendre et innover autour de l'IA. Que vous soyez débutant ou expert, vous trouverez ici un environnement convivial pour explorer le machine learning, le deep learning, le NLP, la vision par ordinateur, et bien plus encore.

--- a/_groups/js-and-co.md
+++ b/_groups/js-and-co.md
@@ -2,12 +2,17 @@
 name: JS & Co Toulouse
 link: https://www.meetup.com/javascript-and-co/
 social:
+  - icon: bi-facebook
+    url: https://www.facebook.com/js.and.co.association/
+    title: "Page Facebook"
   - icon: bi-twitter-x
-    url: http://twitter.com/JS_and_Co
+    url: https://twitter.com/JS_and_Co
     title: "Page X / Twitter"
   - icon: bi-linkedin
     url: https://www.linkedin.com/company/association-js-co
     title: "Page LinkedIn"
 ---
 
-JS&Co est une communauté tech et entrepreneuriale pour apprendre, s'inspirer et échanger autour du développement logiciel et de l'entrepreneuriat.
+JS & Co est une communauté qui rapproche les professionnels de la tech et de l'entrepreneuriat afin de faciliter les échanges entre profils techniques et métiers.
+
+L'association organise des conférences thématiques, des rencontres informelles et le Tech PAF, son afterwork mensuel. Ces événements permettent d'apprendre, de partager les nouveautés du secteur, de développer son réseau et de faire connaître ses projets.

--- a/_groups/jug.md
+++ b/_groups/jug.md
@@ -2,6 +2,12 @@
 name: JUG Toulouse
 link: https://www.meetup.com/toulouse-java-user-group/
 social:
+  - icon: bi-globe
+    url: https://toulousejug.org/
+    title: "Site Web"
+  - icon: bi-github
+    url: https://github.com/ToulouseJug/call-for-paper
+    title: "Proposer ou voter pour un sujet"
   - icon: bi-twitter-x
     url: https://twitter.com/toulousejug
     title: "Page X / Twitter"
@@ -10,4 +16,6 @@ social:
     title: "Page LinkedIn"
 ---
 
-Le Toulouse JUG est un groupe d'utilisateurs Java destiné à échanger des idées et de discuter des avancées technologiques de la JVM.
+Le Toulouse JUG est un groupe d'utilisateurs Java consacré aux échanges autour de Java, de la JVM et de leurs écosystèmes. Ses rencontres gratuites sont ouvertes à toutes et à tous.
+
+Le groupe se retrouve environ une fois par mois pour une présentation technique, une démonstration ou un atelier, puis prolonge les discussions autour d'un buffet. Les membres peuvent proposer des sujets ou voter pour les prochaines sessions.

--- a/_groups/mtg.md
+++ b/_groups/mtg.md
@@ -2,6 +2,15 @@
 name: MTG:Toulouse
 link: https://www.meetup.com/mtg-toulouse/
 social:
+  - icon: bi-globe
+    url: https://www.mtg-toulouse.org/
+    title: "Site Web"
+  - icon: bi-discord
+    url: https://discord.mtg-toulouse.org/
+    title: "Discord"
+  - icon: bi-mic
+    url: https://sessionize.com/mtg
+    title: "Proposer un sujet"
   - icon: bi-twitter-x
     url: https://twitter.com/mtg_toulouse
     title: "Page X / Twitter"
@@ -12,4 +21,4 @@ social:
 
 MTG:Toulouse (Microsoft Tech Group) est une communauté toulousaine centrée sur .NET, Azure et le développement logiciel au sens large.
 
-Le groupe organise des conférences régulières et des moments conviviaux pour apprendre, partager et rencontrer d'autres profils techniques.
+Le groupe organise des conférences régulières et des moments conviviaux pour apprendre, partager et rencontrer d'autres profils techniques dans un environnement inclusif et bienveillant. Les personnes souhaitant intervenir peuvent proposer leur sujet via l'appel à conférences.

--- a/_groups/postgres.md
+++ b/_groups/postgres.md
@@ -10,4 +10,6 @@ social:
     title: "Page LinkedIn"
 ---
 
-Postgres Toulouse est une communauté pour partager autour du moteur de base de données relationnel PostgreSQL, progresser ensemble et découvrir des retours d'expérience concrets.
+Postgres Toulouse est un groupe d'utilisateurs officiellement reconnu par la communauté PostgreSQL. Il accueille toutes les personnes qui souhaitent découvrir ce système de gestion de base de données relationnelle ou approfondir leur pratique.
+
+Les rencontres permettent de partager des expériences, d'apprendre des autres membres et d'aborder des cas d'usage concrets. Les échanges se poursuivent sur le canal Slack de la communauté.

--- a/_groups/python.md
+++ b/_groups/python.md
@@ -1,6 +1,12 @@
 ---
 name: Python Toulouse
 link: https://www.meetup.com/python-toulouse/
+social:
+  - icon: bi-discord
+    url: https://discord.gg/dSSxjwREux
+    title: "Discord"
 ---
 
-On échange autour de Python, de son écosystème, et autour de pizzas 😊 Que ce soit des scripts, des apps, de la data science, de l'IA, ... on en parle !
+Python Toulouse rassemble les utilisateurs et les personnes curieuses de découvrir Python, quel que soit leur niveau ou leur domaine.
+
+Les rencontres abordent le langage et son écosystème à travers des sujets variés : scripts, applications, outils de développement, data science ou intelligence artificielle. Les échanges se prolongent sur le serveur Discord de la communauté.

--- a/_groups/ruby.md
+++ b/_groups/ruby.md
@@ -10,4 +10,6 @@ social:
     title: "Slack"
 ---
 
-Événements (talks, café, boissons) autour de Ruby (principalement) et d'autres langages.
+Toulouse Ruby and Friends rassemble les personnes qui utilisent Ruby ou souhaitent découvrir le langage, quel que soit leur niveau. Les échanges portent principalement sur Ruby, mais restent ouverts à d'autres langages et pratiques de développement.
+
+La communauté organise des talks, ateliers, cafés et apéros pour partager bonnes pratiques, outils et retours d'expérience. Les anciennes présentations sont disponibles sur YouTube et les discussions se poursuivent sur Slack.

--- a/_groups/rust.md
+++ b/_groups/rust.md
@@ -1,6 +1,12 @@
 ---
 name: Rust Toulouse
 link: https://www.meetup.com/fr-FR/rust-community-toulouse/
+social:
+  - icon: bi-linkedin
+    url: https://www.linkedin.com/company/toulouse-rust-meetup
+    title: "Page LinkedIn"
 ---
 
-Un groupe convivial pour échanger autour de Rust et de son écosystème, des bases aux usages plus avancés, avec ce qu'il faut pour alimenter les idées 🍕🍻
+Rust Toulouse est un groupe convivial pour découvrir le langage Rust, approfondir sa pratique et échanger autour de son écosystème.
+
+Les rencontres couvrent aussi bien les bases que des usages avancés, notamment le WebAssembly, les outils en ligne de commande, les serveurs, le jeu vidéo ou l'embarqué. Elles donnent une large place aux démonstrations et aux retours d'expérience.

--- a/_groups/swift.md
+++ b/_groups/swift.md
@@ -2,9 +2,17 @@
 name: Swift Toulouse
 link: https://www.meetup.com/swift-toulouse/
 social:
+  - icon: bi-link-45deg
+    url: https://bento.me/swift-toulouse
+    title: "Tous les liens"
   - icon: bi-linkedin
     url: https://linkedin.com/company/swift-toulouse
     title: "Page LinkedIn"
+  - icon: bi-twitter-x
+    url: https://twitter.com/swifttlsmeetup
+    title: "Page X / Twitter"
 ---
 
-Bienvenue aux Meetup Swift Toulouse ! Parlons développement iOS tous les 2 mois autour de présentations centrées sur le language Swift.
+Swift Toulouse rassemble la communauté locale du développement iOS autour du langage Swift et de son écosystème.
+
+Le groupe organise environ tous les deux mois des présentations techniques et des temps d'échange. Les membres peuvent y découvrir des pratiques, partager leurs retours d'expérience et proposer leurs propres sujets.

--- a/_groups/tds.md
+++ b/_groups/tds.md
@@ -2,9 +2,20 @@
 name: Toulouse Data Science
 link: https://www.meetup.com/tlse-data-science/
 social:
+  - icon: bi-globe
+    url: https://www.tlse-data-science.fr/
+    title: "Site Web"
+  - icon: bi-slack
+    url: https://tinyurl.com/tds-slack
+    title: "Slack"
+  - icon: bi-github
+    url: https://github.com/TlseDataScience/meetup-cfp/issues/new
+    title: "Proposer un sujet"
   - icon: bi-twitter-x
-    url: http://twitter.com/tlse_dasci
+    url: https://twitter.com/tlse_dasci
     title: "Page X / Twitter"
 ---
 
-Le TDS (Toulouse Data Science) est l'association des data héros Toulousains.
+Toulouse Data Science est une association qui crée un lieu d'échange et de partage autour de la valorisation des données massives et de l'analyse prédictive.
+
+La communauté réunit les professionnels et passionnés de la data lors de rencontres consacrées notamment à la data science, au machine learning et à l'intelligence artificielle. Chacun peut également proposer un sujet de présentation via son appel à conférences.

--- a/_groups/tds.md
+++ b/_groups/tds.md
@@ -5,9 +5,6 @@ social:
   - icon: bi-globe
     url: https://www.tlse-data-science.fr/
     title: "Site Web"
-  - icon: bi-slack
-    url: https://tinyurl.com/tds-slack
-    title: "Slack"
   - icon: bi-github
     url: https://github.com/TlseDataScience/meetup-cfp/issues/new
     title: "Proposer un sujet"

--- a/_groups/tech-a-break.md
+++ b/_groups/tech-a-break.md
@@ -1,6 +1,12 @@
 ---
 name: Tech a Break
 link: https://www.meetup.com/tech-a-break/
+social:
+  - icon: bi-envelope
+    url: mailto:tech.a.break.tls@gmail.com
+    title: "Contacter l'équipe"
 ---
 
-On aime la tech et on aime en parler, toi aussi ? Rejoins-nous chez Tech a break !
+Tech a Break est un espace d'échange toulousain animé par des passionnés de technologie. La communauté aborde le cloud, la data, le software craft et de nombreux autres sujets liés au développement logiciel.
+
+Les rencontres ont lieu environ toutes les six semaines et donnent la parole aux membres qui souhaitent partager une idée ou un retour d'expérience, dans une ambiance conviviale.

--- a/_groups/tech-speak-her.md
+++ b/_groups/tech-speak-her.md
@@ -5,6 +5,11 @@ social:
   - icon: bi-linkedin
     url: https://www.linkedin.com/company/tech-speak-her
     title: "Page LinkedIn"
+  - icon: bi-youtube
+    url: https://www.youtube.com/@TechSpeakHer
+    title: "Chaîne YouTube"
 ---
 
-Une communauté de femmes dans la Tech pour passer de la salle à la scène.
+Tech Speak'her est une communauté de femmes de la tech qui souhaitent partager leur expertise et faire entendre leur voix, qu'elles préparent leur premier talk ou interviennent déjà en conférence.
+
+La communauté aide ses membres à passer de la salle à la scène grâce à l'entraide, aux échanges d'expérience et à des occasions de préparer puis présenter leurs sujets.

--- a/_groups/tgd.md
+++ b/_groups/tgd.md
@@ -2,7 +2,25 @@
 name: Toulouse Game Dev
 link: https://toulousegamedev.fr/
 img: none
+social:
+  - icon: bi-discord
+    url: https://discord.gg/ej9YV7r
+    title: "Discord"
+  - icon: bi-bluesky
+    url: https://bsky.app/profile/toulousegamedev.bsky.social
+    title: "Bluesky"
+  - icon: bi-youtube
+    url: https://www.youtube.com/channel/UCdqlwVI1rTyVz_uOQgOM-oQ
+    title: "Chaîne YouTube"
+  - icon: bi-twitch
+    url: https://www.twitch.tv/toulousegamedev
+    title: "Twitch"
+  - icon: bi-linkedin
+    url: https://www.linkedin.com/company/toulouse-game-dev/
+    title: "Page LinkedIn"
 ---
 
 Le Toulouse Game Dev est créé en 2014 pour aider à l'émergence d'une industrie du jeu vidéo sur Toulouse.
 Une décennie plus tard, forts de nos rencontres et de nos actions, nous avons fédéré une grande partie des entreprises, indépendant·e·s, étudiant·e·s et amateur·ices de jeux vidéo à Toulouse.
+
+L'association facilite les échanges entre créateurs et créatrices, partage des ressources et représente les acteurs locaux auprès des institutions. Elle participe également à des festivals et organise des événements en ligne comme en présentiel.

--- a/_groups/toulbox.md
+++ b/_groups/toulbox.md
@@ -1,6 +1,12 @@
 ---
 name: La "Toul Box" du Cloud Natif
 link: https://www.meetup.com/latoulboxducloudnatif/
+social:
+  - icon: bi-mic
+    url: https://conference-hall.io/toul-box-du-cloud-natif
+    title: "Proposer un sujet"
 ---
 
-Groupe toulousain dédié au Cloud Native, avec des retours d'expérience concrets autour du cloud public/hybride, des containers et de l'automatisation.
+La « Toul Box » du Cloud Natif est une communauté toulousaine inspirée par l'écosystème de la Cloud Native Computing Foundation (CNCF).
+
+Elle organise environ tous les deux mois des rencontres fondées sur des retours d'expérience concrets : cloud public ou hybride, conteneurs, automatisation et autres technologies cloud native. Les membres peuvent également proposer leurs propres talks.

--- a/_groups/wordpress-toulouse.md
+++ b/_groups/wordpress-toulouse.md
@@ -8,7 +8,11 @@ social:
   - icon: bi-linkedin
     url: https://www.linkedin.com/company/wordpress-toulouse/
     title: "Page LinkedIn"
+  - icon: bi-slack
+    url: https://join.slack.com/t/wordpressfr/shared_invite/zt-1v2p8bf9g-FdtH97VWDYjHIlMFc8AL5g
+    title: "Slack WordPressFR"
 ---
 
-Depuis mars 2014, le groupe WordPress Toulouse organise des rencontres mensuelles autour de WordPress.
-Ouverts à tou·te·s et gratuits, ces événements permettent de partager nos connaissances autour du monde de WordPress.
+Depuis mars 2014, le groupe WordPress Toulouse organise régulièrement des rencontres autour de WordPress.
+
+Ouverts à tou·te·s et gratuits, ces événements s'adressent aux agences, développeurs, éditeurs et utilisateurs de tous niveaux. Présentations, retours d'expérience et échanges permettent à chacun de progresser et de partager ses connaissances.


### PR DESCRIPTION
## Description

Complète les fiches des communautés afin que leurs pages dédiées proposent un contenu éditorial et des moyens de contact utiles.

- enrichit les descriptions trop courtes à partir des pages Meetup et sites officiels
- ajoute les sites, réseaux sociaux, espaces de discussion et appels à sujets publiés par les communautés
- normalise les liens vers HTTPS
- couvre 25 fiches communautés sur les 28 existantes

## Validation

- build Jekyll réussi sous WSL
- 28 pages communautés générées
- 77 liens communautaires présents dans les pages générées
- URLs ajoutées vérifiées
- classes Bootstrap Icons utilisées vérifiées
- front matter YAML valide

Contribue à #67 sans la clôturer.