### PR TITLE
feat: add dedicated conference pages and enrich conference content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,8 @@ collections:
     output: true
     permalink: /groups/:slug/
   confs:
-    output: false
+    output: true
+    permalink: /conferences/:slug/
   events:
     output: false
 
@@ -22,3 +23,8 @@ defaults:
       type: groups
     values:
       layout: group
+  - scope:
+      path: ""
+      type: confs
+    values:
+      layout: conference

--- a/_confs/agile-tour.md
+++ b/_confs/agile-tour.md
@@ -1,7 +1,7 @@
 ---
 name: Agile Tour Toulouse
 link: https://tour.agiletoulouse.fr/
-dateText: Edition en preparation
+dateText: Édition en préparation
 social:
   - icon: bi-globe
     url: https://tour.agiletoulouse.fr/
@@ -14,6 +14,6 @@ social:
     title: Page X / Twitter
 ---
 
-Agile Tour Toulouse est la declinaison toulousaine d'un rendez-vous historique autour de l'agilite, anime par l'association Agile Toulouse. L'evenement met en avant des retours d'experience, des ateliers et des conferences dedies aux pratiques agiles, au produit, au management et a la transformation des organisations.
+Agile Tour Toulouse est la déclinaison toulousaine d'un rendez-vous historique autour de l'agilité, animé par l'association Agile Toulouse. L'événement met en avant des retours d'expérience, des ateliers et des conférences dédiés aux pratiques agiles, au produit, au management et à la transformation des organisations.
 
-L'edition 2026 a ete annulee et l'association a ouvert une consultation publique sur la suite du format. Cette page permet de suivre les editions a venir et les canaux officiels du collectif organisateur.
+L'édition 2026 a été annulée et l'association a ouvert une consultation publique sur la suite du format. Cette page permet de suivre les éditions à venir et les canaux officiels du collectif organisateur.

--- a/_confs/agile-tour.md
+++ b/_confs/agile-tour.md
@@ -16,4 +16,4 @@ social:
 
 Agile Tour Toulouse est la déclinaison toulousaine d'un rendez-vous historique autour de l'agilité, animé par l'association Agile Toulouse. L'événement met en avant des retours d'expérience, des ateliers et des conférences dédiés aux pratiques agiles, au produit, au management et à la transformation des organisations.
 
-L'édition 2026 a été annulée et l'association a ouvert une consultation publique sur la suite du format. Cette page permet de suivre les éditions à venir et les canaux officiels du collectif organisateur.
+L'édition 2026 a été annulée et l'association Agile Toulouse a ouvert une consultation publique sur la suite du format. L'objectif est de faire évoluer l'événement au plus près des attentes de la communauté agile toulousaine.

--- a/_confs/agile-tour.md
+++ b/_confs/agile-tour.md
@@ -1,7 +1,7 @@
 ---
 name: Agile Tour Toulouse
 link: https://tour.agiletoulouse.fr/
-dateText: 2027
+dateText: Edition en preparation
 social:
   - icon: bi-globe
     url: https://tour.agiletoulouse.fr/
@@ -10,6 +10,10 @@ social:
     url: https://www.linkedin.com/company/agile-toulouse
     title: Page LinkedIn
   - icon: bi-twitter-x
-    url: https://twitter.com/agiletoulouse
+    url: https://x.com/agiletoulouse
     title: Page X / Twitter
 ---
+
+Agile Tour Toulouse est la declinaison toulousaine d'un rendez-vous historique autour de l'agilite, anime par l'association Agile Toulouse. L'evenement met en avant des retours d'experience, des ateliers et des conferences dedies aux pratiques agiles, au produit, au management et a la transformation des organisations.
+
+L'edition 2026 a ete annulee et l'association a ouvert une consultation publique sur la suite du format. Cette page permet de suivre les editions a venir et les canaux officiels du collectif organisateur.

--- a/_confs/capitole-du-libre.md
+++ b/_confs/capitole-du-libre.md
@@ -22,4 +22,4 @@ social:
 
 Le Capitole du Libre est l'un des grands rendez-vous toulousains consacrés au logiciel libre, à l'open source et aux communs numériques. La conférence rassemble un large public autour de keynotes, conférences, ateliers, village associatif, sujets de vie privée, de sécurité, de création et de culture libre.
 
-L'événement se tient sur deux jours à Toulouse et valorise autant les retours d'expérience techniques que les usages concrets du libre. Les canaux référencés ici pointent vers l'organisation officielle et ses annonces pour l'édition à venir.
+L'événement se tient sur deux jours à Toulouse et valorise autant les retours d'expérience techniques que les usages concrets du libre. Il met aussi en avant la richesse du tissu associatif et des communautés engagées autour du logiciel libre.

--- a/_confs/capitole-du-libre.md
+++ b/_confs/capitole-du-libre.md
@@ -20,6 +20,6 @@ social:
     title: Page X / Twitter
 ---
 
-Le Capitole du Libre est l'un des grands rendez-vous toulousains consacres au logiciel libre, a l'open source et aux communs numeriques. La conference rassemble un large public autour de keynotes, conferences, ateliers, village associatif, sujets de vie privee, de securite, de creation et de culture libre.
+Le Capitole du Libre est l'un des grands rendez-vous toulousains consacrés au logiciel libre, à l'open source et aux communs numériques. La conférence rassemble un large public autour de keynotes, conférences, ateliers, village associatif, sujets de vie privée, de sécurité, de création et de culture libre.
 
-L'evenement se tient sur deux jours a Toulouse et valorise autant les retours d'experience techniques que les usages concrets du libre. Les canaux references ici pointent vers l'organisation officielle et ses annonces pour l'edition a venir.
+L'événement se tient sur deux jours à Toulouse et valorise autant les retours d'expérience techniques que les usages concrets du libre. Les canaux référencés ici pointent vers l'organisation officielle et ses annonces pour l'édition à venir.

--- a/_confs/capitole-du-libre.md
+++ b/_confs/capitole-du-libre.md
@@ -1,14 +1,13 @@
 ---
 name: Le Capitole du Libre
-date: 2026-11-14
-end: 2026-11-15
+dateDisplay: 14 et 15 novembre 2026
 link: https://capitoledulibre.org/
 social:
   - icon: bi-globe
     url: https://capitoledulibre.org/
     title: Site Officiel
   - icon: bi-linkedin
-    url: https://linkedin.com/company/capitole-du-libre
+    url: https://www.linkedin.com/company/capitole-du-libre
     title: Page LinkedIn
   - icon: bi-mastodon
     url: https://framapiaf.org/@capitoledulibre
@@ -20,3 +19,7 @@ social:
     url: https://x.com/capitoledulibre
     title: Page X / Twitter
 ---
+
+Le Capitole du Libre est l'un des grands rendez-vous toulousains consacres au logiciel libre, a l'open source et aux communs numeriques. La conference rassemble un large public autour de keynotes, conferences, ateliers, village associatif, sujets de vie privee, de securite, de creation et de culture libre.
+
+L'evenement se tient sur deux jours a Toulouse et valorise autant les retours d'experience techniques que les usages concrets du libre. Les canaux references ici pointent vers l'organisation officielle et ses annonces pour l'edition a venir.

--- a/_confs/cloud-toulouse.md
+++ b/_confs/cloud-toulouse.md
@@ -1,6 +1,6 @@
 ---
 name: Cloud Toulouse
-date: 2026-05-28
+dateDisplay: 28 mai 2026
 link: https://cloudtoulouse.com/
 social:
   - icon: bi-globe
@@ -16,3 +16,7 @@ social:
     url: https://x.com/cloud_toulouse
     title: Page X / Twitter
 ---
+
+Cloud Toulouse est une conference toulousaine entierement dediee aux technologies du cloud. L'evenement reunit des professionnels, des equipes techniques et des entreprises de la region autour d'une vingtaine de conferences, de retours d'experience et d'echanges sur les infrastructures, les plateformes et les pratiques cloud.
+
+L'edition 2026 est annoncee le 28 mai a Toulouse. Cette fiche centralise le site officiel et les canaux verifies de la conference pour suivre le programme, les actualites et l'ouverture des inscriptions.

--- a/_confs/cloud-toulouse.md
+++ b/_confs/cloud-toulouse.md
@@ -17,6 +17,6 @@ social:
     title: Page X / Twitter
 ---
 
-Cloud Toulouse est une conference toulousaine entierement dediee aux technologies du cloud. L'evenement reunit des professionnels, des equipes techniques et des entreprises de la region autour d'une vingtaine de conferences, de retours d'experience et d'echanges sur les infrastructures, les plateformes et les pratiques cloud.
+Cloud Toulouse est une conférence toulousaine entièrement dédiée aux technologies du cloud. L'événement réunit des professionnels, des équipes techniques et des entreprises de la région autour d'une vingtaine de conférences, de retours d'expérience et d'échanges sur les infrastructures, les plateformes et les pratiques cloud.
 
-L'edition 2026 est annoncee le 28 mai a Toulouse. Cette fiche centralise le site officiel et les canaux verifies de la conference pour suivre le programme, les actualites et l'ouverture des inscriptions.
+L'édition 2026 est annoncée le 28 mai à Toulouse. Cette fiche centralise le site officiel et les canaux vérifiés de la conférence pour suivre le programme, les actualités et l'ouverture des inscriptions.

--- a/_confs/cloud-toulouse.md
+++ b/_confs/cloud-toulouse.md
@@ -19,4 +19,4 @@ social:
 
 Cloud Toulouse est une conférence toulousaine entièrement dédiée aux technologies du cloud. L'événement réunit des professionnels, des équipes techniques et des entreprises de la région autour d'une vingtaine de conférences, de retours d'expérience et d'échanges sur les infrastructures, les plateformes et les pratiques cloud.
 
-L'édition 2026 est annoncée le 28 mai à Toulouse. Cette fiche centralise le site officiel et les canaux vérifiés de la conférence pour suivre le programme, les actualités et l'ouverture des inscriptions.
+L'édition 2026 est annoncée le 28 mai à Toulouse. Au programme : des prises de parole de haut niveau, des retours terrain et une soirée conviviale pour prolonger les échanges entre passionné·es du cloud.

--- a/_confs/devfest.md
+++ b/_confs/devfest.md
@@ -20,6 +20,6 @@ social:
     title: Page X / Twitter
 ---
 
-DevFest Toulouse est une conference toulousaine organisee par des developpeuses et developpeurs pour les developpeuses et developpeurs. Elle met en avant des talks techniques et des retours d'experience sur des sujets comme le web, le cloud, la data, l'IA, le mobile, le DevOps et l'ecosysteme logiciel au sens large.
+DevFest Toulouse est une conférence toulousaine organisée par des développeuses et développeurs pour les développeuses et développeurs. Elle met en avant des talks techniques et des retours d'expérience sur des sujets comme le web, le cloud, la data, l'IA, le mobile, le DevOps et l'écosystème logiciel au sens large.
 
-L'evenement s'appuie sur un reseau de partenaires de l'ecosysteme tech local et propose egalement des replays video des editions precedentes. Cette page reference les sources officielles pour suivre la prochaine edition et ses annonces.
+L'événement s'appuie sur un réseau de partenaires de l'écosystème tech local et propose également des replays vidéo des éditions précédentes. Cette page référence les sources officielles pour suivre la prochaine édition et ses annonces.

--- a/_confs/devfest.md
+++ b/_confs/devfest.md
@@ -22,4 +22,4 @@ social:
 
 DevFest Toulouse est une conférence toulousaine organisée par des développeuses et développeurs pour les développeuses et développeurs. Elle met en avant des talks techniques et des retours d'expérience sur des sujets comme le web, le cloud, la data, l'IA, le mobile, le DevOps et l'écosystème logiciel au sens large.
 
-L'événement s'appuie sur un réseau de partenaires de l'écosystème tech local et propose également des replays vidéo des éditions précédentes. Cette page référence les sources officielles pour suivre la prochaine édition et ses annonces.
+L'événement s'appuie sur un réseau de partenaires de l'écosystème tech local et propose également des replays vidéo des éditions précédentes. C'est un rendez-vous phare pour découvrir des retours terrain, rencontrer d'autres profils techniques et suivre les grandes évolutions de la tech.

--- a/_confs/devfest.md
+++ b/_confs/devfest.md
@@ -1,21 +1,25 @@
 ---
 name: DevFest Toulouse
-date: 2026-11-19
+dateDisplay: 19 novembre 2026
 link: https://devfesttoulouse.fr/
 social:
   - icon: bi-globe
     url: https://devfesttoulouse.fr/
     title: Site Officiel
-  - icon: bi-linkedin
-    url: https://www.linkedin.com/company/devfesttoulous
-    title: Page LinkedIn
   - icon: bi-bluesky
     url: https://bsky.app/profile/devfesttoulouse.fr
     title: Page Bluesky
+  - icon: bi-linkedin
+    url: https://www.linkedin.com/company/devfesttoulouse
+    title: Page LinkedIn
   - icon: bi-youtube
     url: https://www.youtube.com/watch?v=3W9hOoGG9N4&list=PLuZ_sYdawLiVt43B2CU1Cm1GVcVApPAlN
     title: Playlist 2025 YouTube
   - icon: bi-twitter-x
-    url: https://twitter.com/devfesttoulouse
+    url: https://x.com/devfesttoulouse
     title: Page X / Twitter
 ---
+
+DevFest Toulouse est une conference toulousaine organisee par des developpeuses et developpeurs pour les developpeuses et developpeurs. Elle met en avant des talks techniques et des retours d'experience sur des sujets comme le web, le cloud, la data, l'IA, le mobile, le DevOps et l'ecosysteme logiciel au sens large.
+
+L'evenement s'appuie sur un reseau de partenaires de l'ecosysteme tech local et propose egalement des replays video des editions precedentes. Cette page reference les sources officielles pour suivre la prochaine edition et ses annonces.

--- a/_confs/pgday.md
+++ b/_confs/pgday.md
@@ -1,7 +1,6 @@
 ---
 name: PGDay Toulouse
-date: 2026-06-03
-end: 2026-06-04
+dateDisplay: 3 et 4 juin 2026
 link: https://pgday.fr/
 social:
   - icon: bi-globe
@@ -14,3 +13,7 @@ social:
     url: https://www.youtube.com/channel/UCR7skKC85Zn6p7fJ-lW7G8g
     title: Chaîne YouTube
 ---
+
+PGDay Toulouse est l'edition toulousaine du rendez-vous annuel de la communaute francophone PostgreSQL. La conference rassemble passionnes, etudiantes et etudiants, DBA, developpeuses, developpeurs et entreprises autour de PostgreSQL, des bases de donnees open source et de leurs usages en production.
+
+L'edition 2026 se deroule les 3 et 4 juin au siege de Meteo-France a Toulouse, avec une journee d'ateliers puis une journee de conferences. Les liens ci-dessus permettent de suivre les informations officielles, le programme et les videos des editions precedentes.

--- a/_confs/pgday.md
+++ b/_confs/pgday.md
@@ -16,4 +16,4 @@ social:
 
 PGDay Toulouse est l'édition toulousaine du rendez-vous annuel de la communauté francophone PostgreSQL. La conférence rassemble passionnés, étudiantes et étudiants, DBA, développeuses, développeurs et entreprises autour de PostgreSQL, des bases de données open source et de leurs usages en production.
 
-L'édition 2026 se déroule les 3 et 4 juin au siège de Météo-France à Toulouse, avec une journée d'ateliers puis une journée de conférences. Les liens ci-dessus permettent de suivre les informations officielles, le programme et les vidéos des éditions précédentes.
+L'édition 2026 se déroule les 3 et 4 juin au siège de Météo-France à Toulouse, avec une journée d'ateliers puis une journée de conférences. Le programme s'adresse autant aux spécialistes de PostgreSQL qu'aux équipes qui souhaitent mieux exploiter les bases de données open source dans leurs projets.

--- a/_confs/pgday.md
+++ b/_confs/pgday.md
@@ -14,6 +14,6 @@ social:
     title: Chaîne YouTube
 ---
 
-PGDay Toulouse est l'edition toulousaine du rendez-vous annuel de la communaute francophone PostgreSQL. La conference rassemble passionnes, etudiantes et etudiants, DBA, developpeuses, developpeurs et entreprises autour de PostgreSQL, des bases de donnees open source et de leurs usages en production.
+PGDay Toulouse est l'édition toulousaine du rendez-vous annuel de la communauté francophone PostgreSQL. La conférence rassemble passionnés, étudiantes et étudiants, DBA, développeuses, développeurs et entreprises autour de PostgreSQL, des bases de données open source et de leurs usages en production.
 
-L'edition 2026 se deroule les 3 et 4 juin au siege de Meteo-France a Toulouse, avec une journee d'ateliers puis une journee de conferences. Les liens ci-dessus permettent de suivre les informations officielles, le programme et les videos des editions precedentes.
+L'édition 2026 se déroule les 3 et 4 juin au siège de Météo-France à Toulouse, avec une journée d'ateliers puis une journée de conférences. Les liens ci-dessus permettent de suivre les informations officielles, le programme et les vidéos des éditions précédentes.

--- a/_includes/conferences.html
+++ b/_includes/conferences.html
@@ -4,21 +4,25 @@
   <div class="my-2 col">
     <div class="card shadow">
       <div class="card-header">📢 {{ conf.name }}</div>
-      <a href="{{ conf.link }}" class="muted">
+      <a href="{{ conf.url | default: conf.link }}" class="muted">
         <img width="100%" style="aspect-ratio: 16/9" src="{{ conf_img_url }}" alt="{{ conf.name }}" />
       </a>
       <div class="card-body">
-        <a href="{{ conf.link }}" class="muted">
-          {% if conf.date %}
+        <a href="{{ conf.url | default: conf.link }}" class="muted">
+          {% if conf.dateDisplay %}
+          <h5 class="card-title">
+            {{ conf.dateDisplay }}
+          </h5>
+          {% elsif conf.dateText %}
+          <h5 class="card-title">
+            {{ conf.dateText }}
+          </h5>
+          {% elsif conf.date %}
           <h5 class="card-title">
             {{ conf.date | date: "%d %B %Y" }}
             {% if conf.end %}
               - {{ conf.end | date: "%d %B %Y" }}
             {% endif %}
-          </h5>          
-          {% elsif conf.dateText %}
-          <h5 class="card-title">
-            {{ conf.dateText }}
           </h5>
           {% endif %}
         </a>

--- a/_includes/conferences.html
+++ b/_includes/conferences.html
@@ -2,11 +2,11 @@
 {% assign conferences_by_name = site.confs | sort_natural: "name" %}
 {% for conf in conferences_by_name %}
 {%- capture conf_img_url -%}{{ site.baseurl }}/confs-imgs/{{ conf.slug }}.jpg{%- endcapture -%}
-{%- assign conference_url = conf.url | default: conf.link -%}
+{%- assign conference_url = conf.url | relative_url -%}
 {%- assign excerpt = conf.content | markdownify | strip_html | strip_newlines | truncate: 120 -%}
 <div class="col">
   <a class="conference-card-item" href="{{ conference_url }}" aria-label="Voir la page de la conférence {{ conf.name | escape }}">
-    <img class="conference-card-image" src="{{ conf_img_url }}" alt="" loading="lazy">
+    <img class="conference-card-image" src="{{ conf_img_url | relative_url }}" alt="" loading="lazy">
     <span class="conference-card-body">
       <span class="conference-card-title">📢 {{ conf.name }}</span>
       {% if excerpt != "" %}

--- a/_includes/conferences.html
+++ b/_includes/conferences.html
@@ -1,38 +1,26 @@
-<div class="row row-cols-1 row-cols-md-2 row-cols-xxl-4">
-  {% for conf in site.confs %}
-  {%- capture conf_img_url -%}/confs-imgs/{{ conf.slug }}.jpg{%- endcapture -%}
-  <div class="my-2 col">
-    <div class="card shadow">
-      <div class="card-header">📢 {{ conf.name }}</div>
-      <a href="{{ conf.url | default: conf.link }}" class="muted">
-        <img width="100%" style="aspect-ratio: 16/9" src="{{ conf_img_url }}" alt="{{ conf.name }}" />
-      </a>
-      <div class="card-body">
-        <a href="{{ conf.url | default: conf.link }}" class="muted">
-          {% if conf.dateDisplay %}
-          <h5 class="card-title">
-            {{ conf.dateDisplay }}
-          </h5>
-          {% elsif conf.dateText %}
-          <h5 class="card-title">
-            {{ conf.dateText }}
-          </h5>
-          {% elsif conf.date %}
-          <h5 class="card-title">
-            {{ conf.date | date: "%d %B %Y" }}
-            {% if conf.end %}
-              - {{ conf.end | date: "%d %B %Y" }}
-            {% endif %}
-          </h5>
-          {% endif %}
-        </a>
-        <div class="d-flex align-items-left">
-          {% for social in conf.social %}
-          <a href="{{ social.url }}" title="{{ social.title }}" class="mx-1 link-secondary"><i class="bi {{ social.icon }}"></i></a>
-          {% endfor %}
-        </div>
-      </div>
-    </div>
-  </div>
-  {% endfor %}
+<div class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 g-3 my-3">
+{% assign conferences_by_name = site.confs | sort_natural: "name" %}
+{% for conf in conferences_by_name %}
+{%- capture conf_img_url -%}{{ site.baseurl }}/confs-imgs/{{ conf.slug }}.jpg{%- endcapture -%}
+{%- assign conference_url = conf.url | default: conf.link -%}
+{%- assign excerpt = conf.content | markdownify | strip_html | strip_newlines | truncate: 120 -%}
+<div class="col">
+  <a class="conference-card-item" href="{{ conference_url }}" aria-label="Voir la page de la conférence {{ conf.name | escape }}">
+    <img class="conference-card-image" src="{{ conf_img_url }}" alt="" loading="lazy">
+    <span class="conference-card-body">
+      <span class="conference-card-title">📢 {{ conf.name }}</span>
+      {% if excerpt != "" %}
+      <span class="conference-card-text">{{ excerpt }}</span>
+      {% endif %}
+      {% if conf.dateDisplay %}
+      <span class="conference-card-badge mt-auto">{{ conf.dateDisplay }}</span>
+      {% elsif conf.dateText %}
+      <span class="conference-card-badge mt-auto">{{ conf.dateText }}</span>
+      {% elsif conf.date %}
+      <span class="conference-card-badge mt-auto">{{ conf.date | date: "%d %B %Y" }}{% if conf.end %} - {{ conf.end | date: "%d %B %Y" }}{% endif %}</span>
+      {% endif %}
+    </span>
+  </a>
+</div>
+{% endfor %}
 </div>

--- a/_layouts/conference.html
+++ b/_layouts/conference.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html prefix="og: https://ogp.me/ns#">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.name | escape }} - Toulouse Tech Hub</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/styles.css">
+    <meta property="og:title" content="{{ page.name | escape }} - Toulouse Tech Hub" />
+    <meta property="og:image" content="{{ site.site }}{{ site.baseurl }}/confs-imgs/{{ page.slug }}.jpg" />
+    <meta property="og:url" content="{{ site.site }}{{ site.baseurl }}{{ page.url }}" />
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-lg navbar-sticky fixed-top">
+        <div class="container">
+            <a class="navbar-brand fw-bold text-white" href="{{ site.baseurl }}/" style="font-size: 1.3rem;">TOULOUSE TECH HUB</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ site.baseurl }}/#agenda">📅 Agenda</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ site.baseurl }}/#conferences">📢 Conférences</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ site.baseurl }}/#communautes">🧑‍💻 Communautés</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container py-4">
+        <div class="row g-4 align-items-start mt-2">
+            <div class="col-lg-6">
+                <img src="{{ site.baseurl }}/confs-imgs/{{ page.slug }}.jpg" class="img-fluid group-hero" alt="Visuel {{ page.name | escape }}" style="aspect-ratio: 16/9; object-fit: cover; width: 100%;">
+            </div>
+            <div class="col-lg-6">
+                <h1 class="group-title mb-3">{{ page.name }}</h1>
+                <div class="d-flex flex-wrap gap-2 align-items-center mb-3">
+                    {% if page.link %}
+                    <a class="btn btn-primary" href="{{ page.link }}" target="_blank" rel="noopener noreferrer">
+                        <i class="bi bi-box-arrow-up-right me-2"></i>Site officiel
+                    </a>
+                    {% endif %}
+                    {% if page.dateDisplay %}
+                    <span class="badge rounded-pill text-bg-light fs-6">
+                        {{ page.dateDisplay }}
+                    </span>
+                    {% elsif page.dateText %}
+                    <span class="badge rounded-pill text-bg-light fs-6">{{ page.dateText }}</span>
+                    {% elsif page.date %}
+                    <span class="badge rounded-pill text-bg-light fs-6">
+                        {{ page.date | date: "%d %B %Y" }}{% if page.end %} - {{ page.end | date: "%d %B %Y" }}{% endif %}
+                    </span>
+                    {% endif %}
+                </div>
+                {% if page.social %}
+                <div class="group-social-links mb-3">
+                    {% for social in page.social %}
+                    <a href="{{ social.url }}" title="{{ social.title | escape }}" target="_blank" rel="noopener noreferrer">
+                        <i class="bi {{ social.icon }}"></i>
+                    </a>
+                    {% endfor %}
+                </div>
+                {% endif %}
+                <div class="group-description">
+                    {{ content }}
+                </div>
+            </div>
+        </div>
+
+        <p class="mt-4 mb-4">
+            <a href="{{ site.baseurl }}/#conferences" class="muted">⬅️ Retour aux conférences</a>
+        </p>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09cYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -129,6 +129,85 @@ a.muted {
     line-height: 1.3;
 }
 
+.conference-card-item {
+    display: flex;
+    gap: 0.95rem;
+    align-items: stretch;
+    height: 100%;
+    padding: 0.95rem;
+    border-radius: 16px;
+    background: linear-gradient(180deg, #ffffff 0%, #f8f9fa 100%);
+    border: 1px solid #dee2e6;
+    box-shadow: 0 4px 14px rgba(0,0,0,0.08);
+    text-decoration: none;
+    color: #212529;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.conference-card-item:hover {
+    transform: translateY(-3px);
+    color: #212529;
+    border-color: rgba(255,137,74,0.55);
+    box-shadow: 0 10px 24px rgba(0,0,0,0.12);
+}
+
+.conference-card-item:focus-visible {
+    outline: 3px solid rgba(255,137,74,0.55);
+    outline-offset: 2px;
+    color: #212529;
+}
+
+.conference-card-image {
+    width: 104px;
+    min-width: 104px;
+    height: 104px;
+    object-fit: cover;
+    border-radius: 14px;
+    background: #ffffff;
+    border: 1px solid #e9ecef;
+}
+
+.conference-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    min-width: 0;
+}
+
+.conference-card-badge {
+    align-self: flex-start;
+    padding: 0.28rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #0c5460;
+    background: rgba(38,166,154,0.12);
+}
+
+.conference-card-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    line-height: 1.3;
+}
+
+.conference-card-text {
+    font-size: 0.93rem;
+    color: #6c757d;
+    line-height: 1.45;
+}
+
+@media (max-width: 575px) {
+    .conference-card-item {
+        padding: 0.85rem;
+    }
+
+    .conference-card-image {
+        width: 88px;
+        min-width: 88px;
+        height: 88px;
+    }
+}
+
 @media (max-width: 575px) {
     .community-links {
         grid-template-columns: 1fr;


### PR DESCRIPTION
Closes #67

## Summary

Adds dedicated conference pages and enriches conference content for SEO and navigation.

## Changes

- enable `_confs` as an output collection with `/conferences/:slug/` permalinks
- add a dedicated `_layouts/conference.html` layout
- update conference cards on the homepage to link to internal conference pages
- enrich all conference entries with French descriptions and verified official/social links
- replace the Jekyll-special `date` usage for conferences with a flexible `dateDisplay` field so pages are generated even when:
  - the conference date is in the future
  - the event spans multiple days
  - only a month is known
  - the exact date is not known yet

## Validation

- `jekyll build` passes in WSL
- generated conference pages:
  - `/conferences/agile-tour/`
  - `/conferences/capitole-du-libre/`
  - `/conferences/cloud-toulouse/`
  - `/conferences/devfest/`
  - `/conferences/pgday/`

## Scope

This PR stays limited to conference-related surfaces:
- `_config.yml`
- `_layouts/conference.html`
- `_includes/conferences.html`
- `_confs/*.md`