### PR TITLE
Add robots.txt and sitemap.xml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 title: Agenda des communautés tech toulousaines
 lang: fr-FR
 site: https://toulouse-tech-hub.fr
+url: https://toulouse-tech-hub.fr
 baseurl: 
 #theme: 
 
@@ -28,3 +29,7 @@ defaults:
       type: confs
     values:
       layout: conference
+  - scope:
+      path: "orgas.html"
+    values:
+      sitemap: false

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,8 @@
+---
+layout: null
+permalink: /robots.txt
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ site.url }}{{ site.baseurl }}/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,7 @@
 ---
 layout: null
 permalink: /robots.txt
+sitemap: false
 ---
 User-agent: *
 Allow: /

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,7 @@
 ---
 layout: null
 permalink: /sitemap.xml
+sitemap: false
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,30 @@
+---
+layout: null
+permalink: /sitemap.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {%- assign pages_for_sitemap = site.html_pages | where_exp: "page", "page.sitemap != false" -%}
+  {%- for page in pages_for_sitemap -%}
+  <url>
+    <loc>{{ site.url }}{{ site.baseurl }}{{ page.url | replace: "index.html", "" }}</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+  </url>
+  {%- endfor -%}
+
+  {%- assign groups_for_sitemap = site.groups | where_exp: "group", "group.sitemap != false" -%}
+  {%- for group in groups_for_sitemap -%}
+  <url>
+    <loc>{{ site.url }}{{ site.baseurl }}{{ group.url }}</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+  </url>
+  {%- endfor -%}
+
+  {%- assign confs_for_sitemap = site.confs | where_exp: "conf", "conf.sitemap != false" -%}
+  {%- for conf in confs_for_sitemap -%}
+  <url>
+    <loc>{{ site.url }}{{ site.baseurl }}{{ conf.url }}</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+  </url>
+  {%- endfor -%}
+</urlset>


### PR DESCRIPTION
## Summary
- add a root `robots.txt` that declares the sitemap URL
- add a Jekyll-generated `sitemap.xml` covering the public site pages
- add the canonical `url` config and exclude `orgas.html` from sitemap indexing

## Validation
- `jekyll build` via WSL succeeds
- generated `robots.txt` points to `https://toulouse-tech-hub.fr/sitemap.xml`
- generated sitemap contains absolute production URLs for the homepage, community pages, conference pages, and legal page

Fixes: #65