### PR TITLE
fix: corrections SEO des balises du `<head>`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: Agenda des communautés tech toulousaines
+description: Retrouvez l'agenda des meetups, conférences et événements tech à Toulouse.
 lang: fr-FR
 site: https://toulouse-tech-hub.fr
 url: https://toulouse-tech-hub.fr

--- a/_layouts/conference.html
+++ b/_layouts/conference.html
@@ -1,17 +1,18 @@
 <!doctype html>
-<html prefix="og: https://ogp.me/ns#">
+<html lang="{{ site.lang }}" prefix="og: https://ogp.me/ns#">
 
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.name | escape }} - Toulouse Tech Hub</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/styles.css">
+    <link rel="canonical" href="{{ site.site }}{{ site.baseurl }}{{ page.url }}" />
     <meta property="og:title" content="{{ page.name | escape }} - Toulouse Tech Hub" />
     <meta property="og:image" content="{{ site.site }}{{ site.baseurl }}/confs-imgs/{{ page.slug }}.jpg" />
     <meta property="og:url" content="{{ site.site }}{{ site.baseurl }}{{ page.url }}" />
+    <meta name="description" content="{{ page.description | default: site.description | escape }}" />
 </head>
 
 <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,18 +1,18 @@
 <!doctype html>
-<html prefix="og: https://ogp.me/ns#">
+<html lang="{{ site.lang }}" prefix="og: https://ogp.me/ns#">
 
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/styles.css">
     <link rel="alternate" type="application/atom+xml" href="{{ site.site }}{{ site.baseurl}}/events.atom.xml" />
     <meta property="og:title" content="Toulouse Tech Hub : {{ page.title }}" />
     <meta property="og:image" content="{{ site.site }}{{ site.baseurl}}/logo.png" />
-    <meta property="og:link" content="{{ site.site }}{{ site.baseurl}}{{ page.url }}" />
+    <meta property="og:url" content="{{ site.site }}{{ site.baseurl}}{{ page.url }}" />
+    <meta name="description" content="{{ page.description | default: site.description }}" />
 </head>
 
 <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,11 +8,16 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/styles.css">
+    <link rel="canonical" href="{{ site.site }}{{ site.baseurl}}{{ page.url }}" />
     <link rel="alternate" type="application/atom+xml" href="{{ site.site }}{{ site.baseurl}}/events.atom.xml" />
-    <meta property="og:title" content="Toulouse Tech Hub : {{ page.title }}" />
+    {%- if page.title == site.title %}
+    <meta property="og:title" content="{{ site.title }}" />
+    {%- else %}
+    <meta property="og:title" content="{{ site.title }} : {{ page.title }}" />
+    {%- endif %}
     <meta property="og:image" content="{{ site.site }}{{ site.baseurl}}/logo.png" />
     <meta property="og:url" content="{{ site.site }}{{ site.baseurl}}{{ page.url }}" />
-    <meta name="description" content="{{ page.description | default: site.description }}" />
+    <meta name="description" content="{{ page.description | default: site.description | escape }}" />
 </head>
 
 <body>

--- a/_layouts/group.html
+++ b/_layouts/group.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html prefix="og: https://ogp.me/ns#">
+<html lang="{{ site.lang }}" prefix="og: https://ogp.me/ns#">
 
 <head>
     <meta charset="utf-8">
@@ -18,12 +18,13 @@
       }
     </script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/styles.css">
+    <link rel="canonical" href="{{ site.site }}{{ site.baseurl }}{{ page.url }}" />
     <meta property="og:title" content="{{ page.name | escape }} - Toulouse Tech Hub" />
     <meta property="og:image" content="{{ site.site }}{{ site.baseurl }}/groups-imgs/{{ page.slug }}.jpg" />
     <meta property="og:url" content="{{ site.site }}{{ site.baseurl }}{{ page.url }}" />
+    <meta name="description" content="{{ page.description | default: site.description | escape }}" />
     <link rel="alternate" type="application/atom+xml" href="{{ site.site }}{{ site.baseurl }}/groups/{{ page.slug }}/feed.xml" />
 </head>
 


### PR DESCRIPTION
Fixes #64

## Problèmes corrigés

- **`og:link` → `og:url`** : `og:link` n'est pas une propriété Open Graph valide
- **Attribut `lang` manquant** : ajout de `lang="{{ site.lang }}"` (`fr-FR`) sur la balise `<html>`
- **Balise `<meta name="description">` absente** : ajout avec fallback vers `site.description` (nouveau champ dans `_config.yml`)
- **CSS Bootstrap en double** : Bootstrap 5.0.2 et 5.3.8 étaient tous les deux chargés — suppression de l'ancienne entrée 5.0.2

## Fichiers modifiés

- `_layouts/default.html`
- `_config.yml` (ajout du champ `description`)