### PR TITLE
Add structured Event data for upcoming events

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -132,8 +132,10 @@ La page d'accueil publie aussi des données structurées `schema.org/Event` au f
 
 - Le balisage est injecté directement dans le HTML via `<script type="application/ld+json">`.
 - Il réutilise le même filtrage que l'agenda : évènements futurs uniquement, avec prise en compte des fichiers `.skip`.
-- Les champs `title`, `link`, `dateIso`, `dateIsoEnd`, `community`, `place`, `placeAddr`, `img` et le contenu HTML de l'évènement servent de source au JSON-LD.
+- Les champs `title`, `link`, `dateIso`, `dateIsoEnd`, `community`, `place`, `placeAddr` et le contenu HTML de l'évènement servent de source au JSON-LD.
+- Le champ `image` du JSON-LD pointe vers l'image locale `event-imgs/{nom-du-fichier-evenement}.webp`, comme les autres sorties du site.
 - Si `dateIsoEnd` est absent, une heure de fin par défaut est dérivée comme pour le flux iCal.
+- La description publiée dans le JSON-LD est un extrait tronqué du contenu HTML de l'évènement, pour limiter le poids de la page.
 - Si `place` est vide, l'évènement est publié comme évènement en ligne avec une `VirtualLocation`.
 
 ## Bonnes pratiques

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,6 +126,16 @@ localImg: event-imgs/unique-id.webp
 <p>Event description in HTML format</p>
 ```
 
+### Données structurées SEO des évènements
+
+La page d'accueil publie aussi des données structurées `schema.org/Event` au format JSON-LD pour les évènements à venir.
+
+- Le balisage est injecté directement dans le HTML via `<script type="application/ld+json">`.
+- Il réutilise le même filtrage que l'agenda : évènements futurs uniquement, avec prise en compte des fichiers `.skip`.
+- Les champs `title`, `link`, `dateIso`, `dateIsoEnd`, `community`, `place`, `placeAddr`, `img` et le contenu HTML de l'évènement servent de source au JSON-LD.
+- Si `dateIsoEnd` est absent, une heure de fin par défaut est dérivée comme pour le flux iCal.
+- Si `place` est vide, l'évènement est publié comme évènement en ligne avec une `VirtualLocation`.
+
 ## Bonnes pratiques
 
 - Les fichiers doivent etre en UTF-8 (voir `.editorconfig`).

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -67,10 +67,16 @@
 </div>
 
 <script type="application/ld+json">
-[
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Prochains evenements Toulouse Tech Hub",
+  "itemListOrder": "https://schema.org/ItemListOrderAscending",
+  "itemListElement": [
 {%- assign now_time = site.time | date: "%s" | plus: 0 -%}
 {%- assign skipped_event_paths = site.events | where_exp: "e", "e.path contains '.skip'" | map: "path" -%}
 {%- assign is_first_structured_event = true -%}
+{%- assign structured_event_position = 0 -%}
 {%- for event in site.events -%}
   {%- if event.path contains ".skip" -%}
     {%- continue -%}
@@ -85,46 +91,51 @@
   {%- endif -%}
   {%- unless is_first_structured_event -%},{%- endunless -%}
   {%- assign is_first_structured_event = false -%}
+  {%- assign structured_event_position = structured_event_position | plus: 1 -%}
   {%- assign event_source_name = event.path | split: "/" | last | split: "." | first -%}
   {%- capture image_url -%}{{ site.site }}{{ site.baseurl }}/event-imgs/{{ event_source_name }}.webp{%- endcapture -%}
   {%- capture event_url -%}{{ event.link }}{%- endcapture -%}
-  {%- capture event_description -%}{{ event.content | strip_html | normalize_whitespace }}{%- endcapture -%}
+  {%- capture event_description -%}{{ event.content | strip_html | normalize_whitespace | truncate: 280 }}{%- endcapture -%}
   {%- capture event_end_date -%}{% if event.dateIsoEnd %}{{ event.dateIsoEnd | date: "%Y-%m-%dT%H:%M:%S%:z" }}{% else %}{{ event.dateIso | date: "%s" | plus: 7200 | date: "%Y-%m-%dT%H:%M:%S%:z" }}{% endif %}{%- endcapture -%}
   {
-    "@context": "https://schema.org",
-    "@type": "Event",
-    "name": {{ event.title | strip | jsonify }},
-    "url": {{ event_url | strip | jsonify }},
-    "startDate": {{ event.dateIso | date: "%Y-%m-%dT%H:%M:%S%:z" | jsonify }},
-    "endDate": {{ event_end_date | strip | jsonify }},
-    "eventAttendanceMode": {% if event.place != null and event.place != "" %}"https://schema.org/OfflineEventAttendanceMode"{% else %}"https://schema.org/OnlineEventAttendanceMode"{% endif %},
-    "eventStatus": "https://schema.org/EventScheduled",
-    "image": [{{ image_url | strip | jsonify }}],
-    "description": {{ event_description | strip | jsonify }},
-    "organizer": {
-      "@type": "Organization",
-      "name": {{ event.community | strip | jsonify }}
-    },
-    {% if event.place != null and event.place != "" %}
-    "location": {
-      "@type": "Place",
-      "name": {{ event.place | strip | jsonify }},
-      "address": {
-        "@type": "PostalAddress",
-        "streetAddress": {{ event.placeAddr | strip | jsonify }},
-        "addressLocality": "Toulouse",
-        "addressCountry": "FR"
+    "@type": "ListItem",
+    "position": {{ structured_event_position }},
+    "item": {
+      "@type": "Event",
+      "name": {{ event.title | strip | jsonify }},
+      "url": {{ event_url | strip | jsonify }},
+      "startDate": {{ event.dateIso | date: "%Y-%m-%dT%H:%M:%S%:z" | jsonify }},
+      "endDate": {{ event_end_date | strip | jsonify }},
+      "eventAttendanceMode": {% if event.place != null and event.place != "" %}"https://schema.org/OfflineEventAttendanceMode"{% else %}"https://schema.org/OnlineEventAttendanceMode"{% endif %},
+      "eventStatus": "https://schema.org/EventScheduled",
+      "image": [{{ image_url | strip | jsonify }}],
+      "description": {{ event_description | strip | jsonify }},
+      "organizer": {
+        "@type": "Organization",
+        "name": {{ event.community | strip | jsonify }}
+      },
+      {% if event.place != null and event.place != "" %}
+      "location": {
+        "@type": "Place",
+        "name": {{ event.place | strip | jsonify }},
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": {{ event.placeAddr | strip | jsonify }},
+          "addressLocality": "Toulouse",
+          "addressCountry": "FR"
+        }
       }
+      {% else %}
+      "location": {
+        "@type": "VirtualLocation",
+        "url": {{ event_url | strip | jsonify }}
+      }
+      {% endif %}
     }
-    {% else %}
-    "location": {
-      "@type": "VirtualLocation",
-      "url": {{ event_url | strip | jsonify }}
-    }
-    {% endif %}
   }
 {%- endfor -%}
-]
+  ]
+}
 </script>
 
 <!-- grid -->

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -66,6 +66,67 @@
   </div>
 </div>
 
+<script type="application/ld+json">
+[
+{%- assign now_time = site.time | date: "%s" | plus: 0 -%}
+{%- assign skipped_event_paths = site.events | where_exp: "e", "e.path contains '.skip'" | map: "path" -%}
+{%- assign is_first_structured_event = true -%}
+{%- for event in site.events -%}
+  {%- if event.path contains ".skip" -%}
+    {%- continue -%}
+  {%- endif -%}
+  {%- assign event_skip_path = event.path | append: ".skip" -%}
+  {%- if skipped_event_paths contains event_skip_path -%}
+    {%- continue -%}
+  {%- endif -%}
+  {%- assign event_time = event.dateIso | date:"%s" | plus: 0 -%}
+  {%- if event_time < now_time -%}
+    {%- continue -%}
+  {%- endif -%}
+  {%- unless is_first_structured_event -%},{%- endunless -%}
+  {%- assign is_first_structured_event = false -%}
+  {%- assign event_source_name = event.path | split: "/" | last | split: "." | first -%}
+  {%- capture image_url -%}{{ site.site }}{{ site.baseurl }}/event-imgs/{{ event_source_name }}.webp{%- endcapture -%}
+  {%- capture event_url -%}{{ event.link }}{%- endcapture -%}
+  {%- capture event_description -%}{{ event.content | strip_html | normalize_whitespace }}{%- endcapture -%}
+  {%- capture event_end_date -%}{% if event.dateIsoEnd %}{{ event.dateIsoEnd | date: "%Y-%m-%dT%H:%M:%S%:z" }}{% else %}{{ event.dateIso | date: "%s" | plus: 7200 | date: "%Y-%m-%dT%H:%M:%S%:z" }}{% endif %}{%- endcapture -%}
+  {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    "name": {{ event.title | strip | jsonify }},
+    "url": {{ event_url | strip | jsonify }},
+    "startDate": {{ event.dateIso | date: "%Y-%m-%dT%H:%M:%S%:z" | jsonify }},
+    "endDate": {{ event_end_date | strip | jsonify }},
+    "eventAttendanceMode": {% if event.place != null and event.place != "" %}"https://schema.org/OfflineEventAttendanceMode"{% else %}"https://schema.org/OnlineEventAttendanceMode"{% endif %},
+    "eventStatus": "https://schema.org/EventScheduled",
+    "image": [{{ image_url | strip | jsonify }}],
+    "description": {{ event_description | strip | jsonify }},
+    "organizer": {
+      "@type": "Organization",
+      "name": {{ event.community | strip | jsonify }}
+    },
+    {% if event.place != null and event.place != "" %}
+    "location": {
+      "@type": "Place",
+      "name": {{ event.place | strip | jsonify }},
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": {{ event.placeAddr | strip | jsonify }},
+        "addressLocality": "Toulouse",
+        "addressCountry": "FR"
+      }
+    }
+    {% else %}
+    "location": {
+      "@type": "VirtualLocation",
+      "url": {{ event_url | strip | jsonify }}
+    }
+    {% endif %}
+  }
+{%- endfor -%}
+]
+</script>
+
 <!-- grid -->
 <div class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 g-3 agenda my-2">
 


### PR DESCRIPTION
## Description

Ajoute des données structurées SEO `schema.org/Event` en JSON-LD sur la page d'accueil pour les évènements à venir.

Closes: #66

## Type de changement

- [x] 🐛 Correction de bug (change non-cassante qui résout un problème)
- [ ] ✨ Nouvelle fonctionnalité (change non-cassante qui ajoute une fonctionnalité)
- [x] 📝 Documentation (modification de README, CONTRIBUTING, etc.)
- [ ] 🎨 Refactorisation (amélioration du code sans changer la fonctionnalité)
- [ ] ⚙️ Dépendances (mise à jour de jekyll, gems, actions, etc.)

## Changements

- Ajoute un bloc `<script type="application/ld+json">` dans le rendu de l'agenda
- Génère un objet `schema.org/Event` pour chaque évènement futur non ignoré
- Documente les champs source du JSON-LD dans `CONTRIBUTING.md`

## Testing

Validation effectuée via WSL.

- [x] `jekyll build` exécuté localement sans erreurs
- [ ] Site visité localement sur http://localhost:4000
- [x] Changements fonctionnels vérifiés
- [x] Aucun changement non intentionnel introduit

### Étapes de test

1. Exécuter `jekyll build` sous WSL à la racine du projet
2. Ouvrir `_site/index.html`
3. Vérifier la présence du bloc `<script type="application/ld+json">`
4. Vérifier la présence d'objets `"@type": "Event"` et du mode de présence attendu

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Aucun fichier `_site/` commité
- [x] Pas de secrets ou credentials commitées
- [x] Les changements résolvent le problème décrit
- [x] J'ai testé localement

## Captures d'écran (si applicable)

N/A

## Notes supplémentaires

Le JSON-LD réutilise le même filtrage que l'agenda HTML pour les évènements futurs et les fichiers `.skip`, afin d'éviter tout décalage entre le contenu visible et le balisage SEO.